### PR TITLE
Fixed code incompatibilities on abstract method

### DIFF
--- a/PaymentMethods/AfterPayAcceptgiro.php
+++ b/PaymentMethods/AfterPayAcceptgiro.php
@@ -152,7 +152,7 @@ class AfterPayAcceptgiro extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/AfterPayB2BAcceptgiro.php
+++ b/PaymentMethods/AfterPayB2BAcceptgiro.php
@@ -152,7 +152,7 @@ class AfterPayB2BAcceptgiro extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/AfterPayB2BDigiAccept.php
+++ b/PaymentMethods/AfterPayB2BDigiAccept.php
@@ -152,7 +152,7 @@ class AfterPayB2BDigiAccept extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/AfterPayDigiAccept.php
+++ b/PaymentMethods/AfterPayDigiAccept.php
@@ -152,7 +152,7 @@ class AfterPayDigiAccept extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/AfterPayNew.php
+++ b/PaymentMethods/AfterPayNew.php
@@ -161,7 +161,7 @@ class AfterPayNew extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
                 
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/Eps.php
+++ b/PaymentMethods/Eps.php
@@ -84,7 +84,7 @@ class Eps extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
     
         $checkData = [];
         return $checkData;

--- a/PaymentMethods/Giropay.php
+++ b/PaymentMethods/Giropay.php
@@ -60,7 +60,7 @@ class Giropay extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/Ideal.php
+++ b/PaymentMethods/Ideal.php
@@ -234,7 +234,7 @@ class Ideal extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/Klarna.php
+++ b/PaymentMethods/Klarna.php
@@ -114,7 +114,7 @@ class Klarna extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/Nexi.php
+++ b/PaymentMethods/Nexi.php
@@ -35,7 +35,7 @@ class Nexi extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         $checkData = [];
         return $checkData;
     }

--- a/PaymentMethods/PayPal.php
+++ b/PaymentMethods/PayPal.php
@@ -255,7 +255,7 @@ class PayPal extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         $checkData = [];
         return $checkData;
     }

--- a/PaymentMethods/Payconiq.php
+++ b/PaymentMethods/Payconiq.php
@@ -35,7 +35,7 @@ class Payconiq extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         $checkData = [];
         return $checkData;
     }

--- a/PaymentMethods/PaymentGuarantee.php
+++ b/PaymentMethods/PaymentGuarantee.php
@@ -71,7 +71,7 @@ class PaymentGuarantee extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         
         $checkData = [];
         $extraFields = $checkPayment['buckaroo-extra-fields'][$this::KEY];

--- a/PaymentMethods/Sofort.php
+++ b/PaymentMethods/Sofort.php
@@ -35,7 +35,7 @@ class Sofort extends AbstractPaymentMethod
     /**
      * Validates the extra fields
      */
-    public function validate($checkPayment) {
+    public function validate($checkPayment, $validatorClass = null) {
         $checkData = [];
         return $checkData;
     }


### PR DESCRIPTION
### Why is this change necessary?
Currently, there are a lot of classes incompatible with it's parent abstract class. This results in warnings. If your application is in production mode, no one will notice anything on the frontend, but you will in your terminal. If you application is in development mode, this will throw an Exception, every time you clear the cache.

![Screenshot from 2019-12-03 19-12-06](https://user-images.githubusercontent.com/48016189/70078998-1b2f8200-1604-11ea-9aec-efe4cd132f3b.png)
