### PR TITLE
Persist attribute with data persister instead of with custom update q…

### DIFF
--- a/Components/ExtraFieldsPersister.php
+++ b/Components/ExtraFieldsPersister.php
@@ -186,24 +186,14 @@ class ExtraFieldsPersister
 
         if( !empty($userAttrColumns) && !empty($userAttrData) )
         {
-           $newAttrUser = array_merge((array)$oldUserAttr, (array)$userAttrData);//$userAttrData   $oldUserAttr
-            if (!isset($newAttrUser['id'])) {
-                $sql = join(' ', [
-                    'INSERT INTO s_user_attributes (',
-                    implode(", ", array_keys($userAttrData)),
-                    ')', 'VALUES(',
-                    implode(", ", array_values($userAttrData)),
-                    ')'
-                ]);
-                $this->em->getConnection()->executeQuery($sql, $newAttrUser);
-            } else {
-                $userId = $userAttrData['id'];
+            $newAttrUser = array_merge((array)$oldUserAttr, (array)$userAttrData);//$userAttrData   $oldUserAttr
 
-                unset($userAttrData['id']);
+            $userId = $userAttrData['id'];
 
-                foreach ($userAttrData as $attribute => $value) {
-                    $this->_dataPersister->persist([$attribute => $value], 's_user_attributes', $userId);
-                }
+            unset($userAttrData['id']);
+
+            foreach ($userAttrData as $attribute => $value) {
+                $this->_dataPersister->persist([$attribute => $value], 's_user_attributes', $userId);
             }
         }
         /**

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -131,6 +131,7 @@
         <service id="buckaroo_payment.extra_fields_persister" class="BuckarooPayment\Components\ExtraFieldsPersister">
             <argument type="service" id="models"/>
             <argument type="service" id="buckaroo_payment.adapter.session"/>
+            <argument type="service" id="shopware_attribute.data_persister"/>
         </service>
 
         <service id="buckaroo_payment.payment_methods.buckaroo"


### PR DESCRIPTION
### Why is this change necessary?
Sometimes, it can happen that a user id isn't set in the attributes table. In this case, the custom `UPDATE` query doesn't do anything at all... Then, as you may have guessed, Buckaroo cannot set any data regarding these attributes.

To fix this, always use the `DataPersister` instead as the `persist()` method will update the user attribute if the user is in the table and it will insert one if it's not already there